### PR TITLE
Fixed compilation on Linux, changed deprecated function in filter demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ FetchContent_MakeAvailable(glfw)
 FetchContent_Declare(iir GIT_REPOSITORY https://github.com/berndporr/iir1) 
 FetchContent_MakeAvailable(iir)
 
+if (LINUX)
+  add_compile_options(-O3 -march=native)
+endif()
+
 if (WIN32)
   set(CMAKE_USE_SCHANNEL ON)
 endif()
@@ -82,7 +86,14 @@ add_library(imgui ${IMGUI_HEADERS} ${IMGUI_SRC})
 if(MSVC)
   target_compile_options(imgui PRIVATE /W4 /WX /arch:AVX2 /fp:fast)
 endif()
-target_link_libraries(imgui PUBLIC glfw glad OpenGL::GL imm32)
+
+if(WIN32)
+  target_link_libraries(imgui PUBLIC glfw glad OpenGL::GL imm32)
+else()
+  target_link_libraries(imgui PUBLIC glfw glad OpenGL::GL)
+endif()
+
+
 target_compile_definitions(imgui PRIVATE IMGUI_DLL_EXPORT)
 
 include_directories(../imgui/ ../imgui/examples ../imgui/examples/libs/gl3w ../imgui/backends ../imgui/misc/cpp)

--- a/common/App.cpp
+++ b/common/App.cpp
@@ -149,7 +149,10 @@ App::App(std::string title, int w, int h, int argc, char const *argv[])
     const bool no_vsync = result["vsync"].as<bool>();
     const bool use_msaa = result["msaa"].as<bool>();
     const bool im_style = result["imgui"].as<bool>();
+
+#if defined(_WIN32)
     NvOptimusEnablement = AmdPowerXpressRequestHighPerformance = result["gpu"].as<bool>();
+#endif
     UsingDGPU = result["gpu"].as<bool>();
 
 #ifdef _DEBUG

--- a/demos/filter.cpp
+++ b/demos/filter.cpp
@@ -70,7 +70,7 @@ struct ImFilter : public App {
         ImGui::SetNextWindowPos(ImVec2(0,0), ImGuiCond_Always);
         ImGui::SetNextWindowSize(GetWindowSize(), ImGuiCond_Always);
         ImGui::Begin("Filter",nullptr, ImGuiWindowFlags_NoResize|ImGuiWindowFlags_NoTitleBar);
-        ImGui::BeginChild("ChildL", ImVec2(ImGui::GetWindowContentRegionWidth() * 0.5f, -1));
+        ImGui::BeginChild("ChildL", ImVec2(ImGui::GetWindowContentRegionMax().x * 0.5f, -1));
         ImGui::Text("Input:    x(t) = A1*sin(2*pi*F1*t) + A2*sin(2*pi*F1*t) + noise");
         ImGui::Separator();
         


### PR DESCRIPTION
Made changes so it compiles properly under Linux, tested with Debian 12 and Ubuntu 22.04.
Also replaced deprecated function GetWindowContentRegionWidth with GetWindowContentRegionMax().x in filter demo.

Fixes #5, deprecates #6 