### PR TITLE
fix: change fmtlib branch to main in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(implot_demos VERSION 0.1.0)
 include(FetchContent) 
 # set(FETCHCONTENT_FULLY_DISCONNECTED ON)
 
-FetchContent_Declare(fmt GIT_REPOSITORY https://github.com/fmtlib/fmt)
+FetchContent_Declare(fmt GIT_REPOSITORY https://github.com/fmtlib/fmt GIT_TAG main)
 FetchContent_MakeAvailable(fmt)
 
 FetchContent_Declare(glfw GIT_REPOSITORY https://github.com/glfw/glfw) 


### PR DESCRIPTION
It seems like `fmtlib` changed their master branch to main, breaking the CMake build. This PR changes it to point to the new main branch instead.